### PR TITLE
Dealing with ttl

### DIFF
--- a/cmd/web/erihttp/types.go
+++ b/cmd/web/erihttp/types.go
@@ -9,6 +9,10 @@ var (
 	ErrUnsupportedContentType = errors.New("unsupported content-type")
 )
 
+var (
+	empty = make([]string, 0)
+)
+
 type ERIResponse interface {
 
 	// Hacking around Generics, like it's 1999.
@@ -22,7 +26,7 @@ type AutoCompleteResponse struct {
 
 func (r *AutoCompleteResponse) PrepareResponse() {
 	if r.Suggestions == nil {
-		r.Suggestions = []string{}
+		r.Suggestions = empty
 	}
 }
 
@@ -34,7 +38,7 @@ type SuggestResponse struct {
 
 func (r *SuggestResponse) PrepareResponse() {
 	if r.Alternatives == nil {
-		r.Alternatives = []string{}
+		r.Alternatives = empty
 	}
 }
 

--- a/cmd/web/erihttp/util.go
+++ b/cmd/web/erihttp/util.go
@@ -11,6 +11,15 @@ import (
 func GetBodyFromHTTPRequest(r *http.Request, maxBodySize int64) ([]byte, error) {
 	var empty []byte
 
+	if r.Method != http.MethodPost {
+		if len(r.Method) > 16 {
+			// If the method value exceeds this size, let's not bother logging it since it might be abuse. Number is arbitrary
+			return empty, ErrInvalidRequest
+		}
+
+		return empty, fmt.Errorf("%w HTTP Method %q is unsupported", ErrInvalidRequest, r.Method)
+	}
+
 	if r.Body == nil {
 		return empty, ErrMissingBody
 	}
@@ -21,7 +30,7 @@ func GetBodyFromHTTPRequest(r *http.Request, maxBodySize int64) ([]byte, error) 
 
 	if ct := r.Header.Get("Content-Type"); ct != "application/json" {
 		if len(ct) > 128 {
-			// An arbitrary number. If the header value exceeds this size, let's not bother logging it since it might be abuse
+			// If the header value exceeds this size, let's not bother logging it since it might be abuse. Number is arbitrary
 			return empty, ErrUnsupportedContentType
 		}
 

--- a/cmd/web/erihttp/util_test.go
+++ b/cmd/web/erihttp/util_test.go
@@ -30,10 +30,22 @@ func TestGetBodyFromHTTPRequest(t *testing.T) {
 			want: []byte("{}"),
 		},
 		{
+			wantErr: ErrInvalidRequest,
+			name:    "Not POST",
+			req: func(_ []byte) *http.Request {
+				req := httptest.NewRequest(http.MethodGet, "/", nil)
+				req.Header.Set("Content-Type", "application/json")
+				req.Body = nil
+
+				return req
+			},
+			want: nil,
+		},
+		{
 			wantErr: ErrMissingBody,
 			name:    "Nil body",
 			req: func(_ []byte) *http.Request {
-				req := httptest.NewRequest(http.MethodGet, "/", nil)
+				req := httptest.NewRequest(http.MethodPost, "/", nil)
 				req.Header.Set("Content-Type", "application/json")
 				req.Body = nil
 

--- a/cmd/web/services/autocomplete.go
+++ b/cmd/web/services/autocomplete.go
@@ -44,7 +44,7 @@ func (a *AutocompleteSvc) Autocomplete(ctx context.Context, domain string, limit
 		return AutocompleteResult{}, ErrInputTooLong
 	}
 
-	// Fetching a bit more, to create a greater change we're left with a proper limit when done filtering
+	// Fetching a bit more, to have a greater chance that we're left with enough when we're done with filtering
 	list, err := a.finder.GetMatchingPrefix(ctx, domain, uint(limit*2))
 	if err != nil {
 		return AutocompleteResult{}, err

--- a/cmd/web/services/suggest.go
+++ b/cmd/web/services/suggest.go
@@ -61,6 +61,7 @@ func (c *SuggestSvc) Suggest(ctx context.Context, email string) (SuggestResult, 
 			"steps":       vr.Steps.String(),
 			"validations": vr.Validations.String(),
 		}).Debug("Input doesn't have a valid structure")
+
 		err = validator.ErrEmailAddressSyntax
 	}
 
@@ -82,7 +83,7 @@ func (c *SuggestSvc) Suggest(ctx context.Context, email string) (SuggestResult, 
 		parts := types.NewEmailFromParts(parts.Local, alt)
 		return SuggestResult{
 			Alternatives: []string{parts.Address},
-		}, nil
+		}, err
 	}
 
 	return sr, err

--- a/cmd/web/util.go
+++ b/cmd/web/util.go
@@ -214,10 +214,11 @@ func createPersister(conf config.Config, logger logrus.FieldLogger, hitList *hit
 	}
 
 	var added uint64
+	logger.Debug("Backend defined, starting read and building memory structures")
 	err := backend.Range(context.Background(), func(d hitlist.Domain, r hitlist.Recipient, vr validator.Result) error {
 		err := hitList.AddInternalParts(d, r, vr, time.Hour*60)
 		if err != nil {
-			logger.WithError(err).Warn("Unable hydrate hitList")
+			logger.WithError(err).Warn("Unable to hydrate hitList")
 		}
 
 		added++

--- a/cmd/web/util.go
+++ b/cmd/web/util.go
@@ -216,7 +216,7 @@ func createPersister(conf config.Config, logger logrus.FieldLogger, hitList *hit
 	var added uint64
 	logger.Debug("Backend defined, starting read and building memory structures")
 	err := backend.Range(context.Background(), func(d hitlist.Domain, r hitlist.Recipient, vr validator.Result) error {
-		err := hitList.AddInternalParts(d, r, vr, time.Hour*60)
+		err := hitList.AddInternalParts(d, r, vr)
 		if err != nil {
 			logger.WithError(err).Warn("Unable to hydrate hitList")
 		}

--- a/validator/types.go
+++ b/validator/types.go
@@ -3,6 +3,7 @@ package validator
 import (
 	"context"
 	"net"
+	"time"
 
 	"github.com/Dynom/ERI/types"
 	"github.com/Dynom/ERI/validator/validations"
@@ -24,6 +25,12 @@ type stateFn func(a *Artifact) error
 type Result struct {
 	Validations validations.Validations
 	Steps       validations.Steps
+}
+
+type Details struct {
+	Result
+
+	ValidUntil time.Time
 }
 
 func (r Result) ValidatorsRan() bool {

--- a/validator/util.go
+++ b/validator/util.go
@@ -24,7 +24,7 @@ func getNewArtifact(ctx context.Context, ep types.EmailParts, options ...Artifac
 		Steps:       0,
 		Timings:     make(Timings, 10),
 		email:       ep,
-		mx:          []string{""},
+		mx:          nil,
 		ctx:         ctx,
 		dialer: &net.Dialer{
 			Timeout: time.Second * 60,
@@ -92,11 +92,11 @@ func fetchMXHosts(ctx context.Context, resolver LookupMX, domain string) ([]stri
 
 	mxs, err := resolver.LookupMX(ctx, domain)
 	if err != nil {
-		return []string{}, fmt.Errorf("MX lookup failed %w", err)
+		return nil, fmt.Errorf("MX lookup failed %w", err)
 	}
 
 	if len(mxs) == 0 {
-		return []string{}, fmt.Errorf("no MX records found %w", err)
+		return nil, fmt.Errorf("no MX records found %w", err)
 	}
 
 	// Reading an external source, limiting to a liberal amount

--- a/validator/util_test.go
+++ b/validator/util_test.go
@@ -61,9 +61,11 @@ func Test_fetchMXHosts(t *testing.T) {
 		{name: "Happy flow", want: []string{"mx1.example.org"}, args: args{hosts: []string{"mx1.example.org"}}},
 
 		// The bad
-		{wantErr: true, name: "no MX records", want: []string{}, args: args{hosts: []string{}}},
+		{wantErr: true, name: "no MX records", want: nil, args: args{hosts: []string{}}},
+		{wantErr: true, name: "lookup error", want: nil, args: args{hosts: []string{"."}, err: errors.New("err")}},
+
+		// We had a result, but all were invalid. The result is an empty slice instead of a nil slice.
 		{wantErr: true, name: "malformed MX records", want: []string{}, args: args{hosts: []string{"."}}},
-		{wantErr: true, name: "lookup error", want: []string{}, args: args{hosts: []string{"."}, err: errors.New("err")}},
 	}
 
 	ctx := context.Background()
@@ -78,7 +80,7 @@ func Test_fetchMXHosts(t *testing.T) {
 			}
 
 			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("fetchMXHosts() got = %v, want %v", got, tt.want)
+				t.Errorf("fetchMXHosts() got = %#v, want %#v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
This PR changes the way we're dealing with the TTL of collected information. Now, when an entry's freshness expired, a lookup is forced when a request comes in, but its value is still used in alternative recommendations if it was once seen as good. This results in a larger window where previously considered good domains can still be used as alternative, without being actually requested themselves.

I think this proves for a better real-world implementation and I'm getting more pleased with Hitlist's API.