### PR TITLE
Adding preferred domains

### DIFF
--- a/cmd/web/config.toml
+++ b/cmd/web/config.toml
@@ -117,3 +117,12 @@
 
     # The maximum number of suggestions to return
     maxSuggestions = 5
+
+
+  [services.suggest]
+
+    # Prefer allows mapping correct domains to favor alternative domains. A common example could be to map frequently
+    # occurring typos e.g.: example.com to point to example.org. The result is that when a mapping is found for a given
+    # domain, the preferred variant is prepended in the list of alternatives. The left-hand-side must be unique.
+    [services.suggest.prefer]
+      # The syntax is: "<domain>" = "<preferred domain>"

--- a/cmd/web/handlers_test.go
+++ b/cmd/web/handlers_test.go
@@ -305,7 +305,7 @@ func TestNewSuggestHandler(t *testing.T) {
 			}
 		}
 
-		svc := services.NewSuggestService(myFinder, val, logger)
+		svc := services.NewSuggestService(myFinder, val, nil, logger)
 
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
@@ -358,7 +358,7 @@ func TestNewSuggestHandler(t *testing.T) {
 			}
 
 			// Building the service
-			svc := services.NewSuggestService(myFinder, val, logger)
+			svc := services.NewSuggestService(myFinder, val, nil, logger)
 			handlerFunc := NewSuggestHandler(logger, svc, maxBodySize)
 
 			// Setting up the request

--- a/cmd/web/main.go
+++ b/cmd/web/main.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/Dynom/ERI/cmd/web/preferrer"
 	"github.com/Dynom/ERI/cmd/web/pubsub/gcp"
 	"github.com/Dynom/ERI/runtimer"
 	"github.com/rs/cors"
@@ -110,8 +111,10 @@ func main() {
 		os.Exit(1)
 	}
 
+	prefer := preferrer.New(preferrer.Mapping(conf.Services.Suggest.Prefer))
+
 	validatorFn := createProxiedValidator(conf, logger, hitList, myFinder, pubSubSvc, persister)
-	suggestSvc := services.NewSuggestService(myFinder, validatorFn, logger)
+	suggestSvc := services.NewSuggestService(myFinder, validatorFn, prefer, logger)
 	autocompleteSvc := services.NewAutocompleteService(myFinder, hitList, conf.Services.Autocomplete.RecipientThreshold, logger)
 
 	mux := http.NewServeMux()

--- a/cmd/web/preferrer/preferrer.go
+++ b/cmd/web/preferrer/preferrer.go
@@ -1,0 +1,29 @@
+package preferrer
+
+import "github.com/Dynom/ERI/types"
+
+type HasPreferred interface {
+	HasPreferred(parts types.EmailParts) (string, bool)
+}
+
+type Mapping map[string]string
+
+func New(mapping Mapping) *Preferrer {
+	return &Preferrer{
+		m: mapping,
+	}
+}
+
+type Preferrer struct {
+	m Mapping
+}
+
+// HasPreferred returns the input when there isn't a match or a preferred result if it has. The second return argument
+// should be used to discriminate between the two.
+func (p *Preferrer) HasPreferred(parts types.EmailParts) (string, bool) {
+	if l, ok := p.m[parts.Domain]; ok {
+		return l, true
+	}
+
+	return parts.Domain, false
+}

--- a/cmd/web/preferrer/preferrer_test.go
+++ b/cmd/web/preferrer/preferrer_test.go
@@ -1,0 +1,58 @@
+package preferrer
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/Dynom/ERI/types"
+)
+
+func TestNew(t *testing.T) {
+	type args struct {
+		mapping Mapping
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want *Preferrer
+	}{
+		{name: "nil map", args: args{mapping: nil}, want: &Preferrer{}},
+		{name: "populated 1", args: args{mapping: Mapping{"a": "b"}}, want: &Preferrer{m: Mapping{"a": "b"}}},
+		{name: "populated N", args: args{mapping: Mapping{"a": "b", "b": "c"}}, want: &Preferrer{m: Mapping{"a": "b", "b": "c"}}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := New(tt.args.mapping); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("New() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPreferrer_HasPreferred(t *testing.T) {
+	tests := []struct {
+		name  string
+		m     Mapping
+		parts types.EmailParts
+		want  string
+		has   bool
+	}{
+
+		{name: "nil map", m: nil, parts: types.NewEmailFromParts("john.doe", "example.org"), want: "example.org", has: false},
+		{name: "match", m: Mapping{"example.com": "example.org"}, parts: types.NewEmailFromParts("john.doe", "example.com"), want: "example.org", has: true},
+		{name: "no match", m: Mapping{"a": "b"}, parts: types.NewEmailFromParts("john.doe", "example.org"), want: "example.org", has: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &Preferrer{
+				m: tt.m,
+			}
+
+			got, has := p.HasPreferred(tt.parts)
+			if got != tt.want || has != tt.has {
+				t.Errorf("HasPreferred() got = %v, %t; want %v, %t", got, has, tt.want, tt.has)
+			}
+		})
+	}
+}

--- a/cmd/web/services/suggest.go
+++ b/cmd/web/services/suggest.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/Dynom/ERI/cmd/web/erihttp/handlers"
+	"github.com/Dynom/ERI/cmd/web/preferrer"
 
 	"github.com/Dynom/ERI/validator"
 
@@ -14,11 +15,16 @@ import (
 	"github.com/Dynom/TySug/finder"
 )
 
-func NewSuggestService(f *finder.Finder, val validator.CheckFn, logger logrus.FieldLogger) *SuggestSvc {
+func NewSuggestService(f *finder.Finder, val validator.CheckFn, prefer preferrer.HasPreferred, logger logrus.FieldLogger) *SuggestSvc {
+	if prefer == nil {
+		prefer = preferrer.New(nil)
+	}
+
 	return &SuggestSvc{
 		finder:    f,
 		validator: val,
 		logger:    logger.WithField("svc", "suggest"),
+		prefer:    prefer,
 	}
 }
 
@@ -26,6 +32,7 @@ type SuggestSvc struct {
 	finder    *finder.Finder
 	validator validator.CheckFn
 	logger    *logrus.Entry
+	prefer    preferrer.HasPreferred
 }
 
 type SuggestResult struct {
@@ -76,6 +83,24 @@ func (c *SuggestSvc) Suggest(ctx context.Context, email string) (SuggestResult, 
 			sr.Alternatives = alts
 		}
 	}
+
+	var alts = make([]string, 0, len(sr.Alternatives))
+	for _, alt := range sr.Alternatives {
+		parts, err := types.NewEmailParts(alt)
+		if err != nil {
+			log.WithError(err).Error("Input doesn't have valid structure")
+			continue
+		}
+
+		if preferred, exists := c.prefer.HasPreferred(parts); exists {
+			parts := types.NewEmailFromParts(parts.Local, preferred)
+			alts = append(alts, parts.Address, alt)
+		} else {
+			alts = append(alts, alt)
+		}
+	}
+
+	sr.Alternatives = alts
 
 	return sr, err
 }

--- a/cmd/web/services/suggest_test.go
+++ b/cmd/web/services/suggest_test.go
@@ -73,6 +73,15 @@ func TestSuggestSvc_Suggest(t *testing.T) {
 			finderList: []string{"example.org"},
 		},
 		{
+			name:       "Invalid domain, should fall back on finder and be corrected by preferrer",
+			email:      "john.doe@example.cm",
+			want:       SuggestResult{Alternatives: []string{"john.doe@example.org"}},
+			wantErr:    false,
+			validator:  createMockValidator(validations.FSyntax, validations.FSyntax),
+			finderList: []string{"example.org"},
+			preferMap:  preferrer.Mapping{"example.com": "example.org"},
+		},
+		{
 			name:       "Invalid domain, finder has no alternative",
 			email:      "john.doe@example.or",
 			want:       SuggestResult{Alternatives: []string{"john.doe@example.or"}},


### PR DESCRIPTION
Certain e-mail providers discriminate based on their TLD. Hotmail, for example, can have e-mail addresses on Hotmail.fr or Hotmail.nl which won't work on Hotmail.com. While all domains are legitimate e-mail receiving domains.

To compensate for this behaviour, I've added the feature to have a preferred mapping. This PR introduces the mapping, which you can specify in the configuration file or as runtime flags. This allows you to hint your users to a more preferred domain, while keeping the option open to allow for their specific choice.

The preferred alternative will be prepended to the otherwise found alternative. This means it'll also work on bad (but syntactically valid) results.

## Example
This will offer the following suggestion:
**Request**
```json
{
    "email": "this-is-just-a-test@hotmail.ln"
}
```
**Response**
```json
{
    "alternatives": [
        "this-is-just-a-test@hotmail.com",
        "this-is-just-a-test@hotmail.nl"
    ],
    "malformed_syntax": false
}
```

## Configuration
**config.toml**
```toml
     [services.suggest.prefer]
        # The syntax is: "<domain>" = "<preferred domain>"
        "hotmail.fr" = "hotmail.com"
        "hotmail.nl" = "hotmail.com"
```
**flags**
The equivalent with flags: 
```sh
./web --services-suggest-prefer hotmail.fr=hotmail.com --services-suggest-prefer hotmail.nl=hotmail.com
```